### PR TITLE
fix: Resolve langchain import error and add Pillow dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import markdown2
 
 # RAG specific imports
 from langchain_community.document_loaders import PyPDFLoader, TextLoader, Docx2txtLoader
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 # --- CORRECTION 1: Mise à jour de l'import pour suivre l'avertissement ---
 from langchain_community.vectorstores import FAISS # Ancien import: from langchain.vectorstores import FAISS
 from langchain_community.embeddings import HuggingFaceEmbeddings

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ transformers @ git+https://github.com/huggingface/transformers.git@main
 # RAG Dependencies
 langchain
 langchain-community
+langchain-text-splitters
 sentence-transformers
 faiss-cpu
+Pillow
 pypdf
 python-docx


### PR DESCRIPTION
This commit addresses a `ModuleNotFoundError` for `RecursiveCharacterTextSplitter` by updating the import statement to use the new `langchain_text_splitters` package and adding it to `requirements.txt`.

Additionally, this commit adds the `Pillow` library to `requirements.txt`, which was a missing dependency required for the new vision-language model functionality.